### PR TITLE
fixing tycho warning about missing explicit target env conf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,33 @@
 							<version>${project.version}</version>
 						</artifact>
 					</target>
+                                        <environments>
+                                                <environment>
+                                                        <os>macosx</os>
+                                                        <ws>cocoa</ws>
+                                                        <arch>x86_64</arch>
+                                                </environment>
+                                                <environment>
+                                                        <os>win32</os>
+                                                        <ws>win32</ws>
+                                                        <arch>x86</arch>
+                                                </environment>
+                                                <environment>
+                                                        <os>win32</os>
+                                                        <ws>win32</ws>
+                                                        <arch>x86_64</arch>
+                                                </environment>
+                                                <environment>
+                                                        <os>linux</os>
+                                                        <ws>gtk</ws>
+                                                        <arch>x86</arch>
+                                                </environment>
+                                                <environment>
+                                                        <os>linux</os>
+                                                        <ws>gtk</ws>
+                                                        <arch>x86_64</arch>
+                                                </environment>
+                                        </environments>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
without configuring explicit target environments tycho
complains in the following way:

[WARNING] No explicit target runtime environment configuration. Build is platform dependent.

Signed-off-by: Andre Dietisheim <adietish@redhat.com>