### PR TITLE
fix gson error upon client connecting: ClientCapabilitiesRequest

### DIFF
--- a/api/bundles/org.jboss.tools.rsp.api/src/main/java/org/jboss/tools/rsp/api/dao/ClientCapabilitiesRequest.java
+++ b/api/bundles/org.jboss.tools.rsp.api/src/main/java/org/jboss/tools/rsp/api/dao/ClientCapabilitiesRequest.java
@@ -11,11 +11,21 @@ package org.jboss.tools.rsp.api.dao;
 import java.util.Map;
 
 public class ClientCapabilitiesRequest {
+
 	private Map<String,String> map;
+
+	public ClientCapabilitiesRequest() {
+	}
+
 	public ClientCapabilitiesRequest(Map<String,String> map) {
 		this.map = map;
 	}
+
 	public Map<String,String> getMap() {
 		return map;
+	}
+
+	public void setMap(Map<String,String> map) {
+		this.map = map;
 	}
 }


### PR DESCRIPTION
GRAVE: Unable to invoke no-args constructor for class org.jboss.tools.rsp.api.dao.ClientCapabilitiesRequest. Register an Instanc
ay fix this problem.
java.lang.RuntimeException: Unable to invoke no-args constructor for class org.jboss.tools.rsp.api.dao.ClientCapabilitiesRequest
 Gson for this type may fix this problem.

Signed-off-by: Andre Dietisheim <adietish@redhat.com>