### PR TITLE
#152 Incorrect GSON lib handling

### DIFF
--- a/api/bundles/org.jboss.tools.rsp.api/META-INF/MANIFEST.MF
+++ b/api/bundles/org.jboss.tools.rsp.api/META-INF/MANIFEST.MF
@@ -6,7 +6,6 @@ Bundle-Version: 0.11.0.qualifier
 Automatic-Module-Name: org.jboss.tools.rsp.api
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .,
- lib/gson-2.8.2.jar,
  lib/org.eclipse.lsp4j.jsonrpc-0.4.1.jar
 Import-Package: org.osgi.framework
 Export-Package: com.google.gson,
@@ -25,4 +24,5 @@ Export-Package: com.google.gson,
  org.jboss.tools.rsp.api,
  org.jboss.tools.rsp.api.dao,
  org.jboss.tools.rsp.api.dao.util
+Require-Bundle: com.google.gson
 

--- a/api/bundles/org.jboss.tools.rsp.api/pom.xml
+++ b/api/bundles/org.jboss.tools.rsp.api/pom.xml
@@ -14,7 +14,6 @@
 	<name>Runtime Server Protocol : API</name>
 
 	<properties>
-	  <gson.version>2.8.2</gson.version>
 	  <lsp4j.jsonrpc.version>0.4.1</lsp4j.jsonrpc.version>
 	</properties>
 	
@@ -36,11 +35,6 @@
 				<configuration>
 				      <skip>false</skip>
 				      <artifactItems>
-					<artifactItem>
-						<groupId>com.google.code.gson</groupId>
-						<artifactId>gson</artifactId>
-						<version>${gson.version}</version>
-					</artifactItem>
 					<artifactItem>
 						<groupId>org.eclipse.lsp4j</groupId>
 						<artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>


### PR DESCRIPTION
Signed-off-by: Dmitrii Bocharov <dbocharo@redhat.com>

I tried to add it to "Import-Package" instead of "Require-Bundle", but it didn't work - i don't know why. Eclipse manages it fine and shows gson lib in Plug-in Dependencies, however maven build fails.  "Require-Bundle" works fine. 