### PR TITLE
generated incoming.ts with remove listener methods (#373)

### DIFF
--- a/api/bundles/org.jboss.tools.rsp.api/src/main/java/org/jboss/tools/rsp/api/RSPClient.java
+++ b/api/bundles/org.jboss.tools.rsp.api/src/main/java/org/jboss/tools/rsp/api/RSPClient.java
@@ -32,8 +32,6 @@ public interface RSPClient {
 	@JsonRequest
 	CompletableFuture<String> promptString(StringPrompt prompt);
 
-
-
 	/**
 	 * The `client/discoveryPathAdded` notification is sent by the server to all
 	 * clients in response to the `server/addDiscoveryPath` notification.

--- a/api/docs/org.jboss.tools.rsp.schema/src/main/java/org/jboss/tools/rsp/api/schema/JavadocUtilities.java
+++ b/api/docs/org.jboss.tools.rsp.schema/src/main/java/org/jboss/tools/rsp/api/schema/JavadocUtilities.java
@@ -1,9 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2018-2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * All rights reserved. This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * Contributors: Red Hat, Inc.
+ ******************************************************************************/
 package org.jboss.tools.rsp.api.schema;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import com.github.javaparser.JavaParser;
@@ -17,19 +26,22 @@ import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 
 public class JavadocUtilities {
 
-	public static HashMap<String, JavadocComment> methodToJavadocMap(File f) {
+	private JavadocUtilities() {
+		// inhibit instantiation
+	}
+	
+	public static Map<String, JavadocComment> methodToJavadocMap(File f) {
 		HashMap<String, JavadocComment> map = new LinkedHashMap<>();
-		VoidVisitorAdapter adapter = new VoidVisitorAdapter<Object>() {
+		VoidVisitorAdapter<Object> adapter = new VoidVisitorAdapter<Object>() {
 			@Override
 			public void visit(JavadocComment comment, Object arg) {
 				super.visit(comment, arg);
 				Optional<Node> o = comment.getCommentedNode();
-				if (o.get() != null) {
-					if (!(o.get() instanceof CompilationUnit)) {
-						Node n = o.get();
-						if (n instanceof MethodDeclaration) {
-							map.put(((MethodDeclaration)n).getNameAsString(), comment);
-						}
+				if (o.isPresent()
+					&& (!(o.get() instanceof CompilationUnit))) {
+					Node n = o.get();
+					if (n instanceof MethodDeclaration) {
+						map.put(((MethodDeclaration)n).getNameAsString(), comment);
 					}
 				}
 			}
@@ -44,6 +56,9 @@ public class JavadocUtilities {
 	}
 	
 	public static boolean isNotification(MethodDeclaration dec) {
+		if (dec == null) {
+			return false;
+		}
 		NodeList<AnnotationExpr> annotations = dec.getAnnotations();
 		for( AnnotationExpr a : annotations) {
 			String annotName = annotations.get(0).getNameAsString();
@@ -55,6 +70,9 @@ public class JavadocUtilities {
 	}
 
 	public static boolean isRequest(MethodDeclaration dec) {
+		if (dec == null) {
+			return false;
+		}
 		NodeList<AnnotationExpr> annotations = dec.getAnnotations();
 		for( AnnotationExpr a : annotations) {
 			String annotName = annotations.get(0).getNameAsString();

--- a/api/docs/org.jboss.tools.rsp.schema/src/main/java/org/jboss/tools/rsp/api/schema/TypescriptUtility.java
+++ b/api/docs/org.jboss.tools.rsp.schema/src/main/java/org/jboss/tools/rsp/api/schema/TypescriptUtility.java
@@ -401,15 +401,27 @@ public class TypescriptUtility {
 		String retTypeName = convertReturnType(retType.toString());
 
 		if( JavadocUtilities.isNotification(md) ) {
-			sb.append("    on" + capName + "(listener: (arg: " + paramType + ") => " + retTypeName + "): void {\n");
-			sb.append("        this.emitter.on('" + methodName + "', listener);\n");
-			sb.append("    }\n");
+			printOneAddRemoveListener(sb, methodName, capName, paramType, retTypeName);
 		} else {
 			String requestName = methodNameToRequestName(methodName);
 			sb.append("    on" + capName + "(listener: (arg: " + paramType + ") => Promise<" + retTypeName + ">): void {\n");
 			sb.append("        this.connection.onRequest(Messages.Client." + requestName + ".type, listener);\n");
 			sb.append("    }\n");
 		}
+	}
+
+	private void printOneAddRemoveListener(StringBuilder sb, String methodName, String capName, String paramType,
+			String retTypeName) {
+		// add listener
+		sb.append("\n");
+		sb.append("    on" + capName + "(listener: (arg: " + paramType + ") => " + retTypeName + "): void {\n");
+		sb.append("        this.emitter.on('" + methodName + "', listener);\n");
+		sb.append("    }\n");
+		// remove listener
+		sb.append("\n");
+		sb.append("    removeOn" + capName + "(listener: (arg: " + paramType + ") => " + retTypeName + "): void {\n");
+		sb.append("        this.emitter.removeListener('" + methodName + "', listener);\n");
+		sb.append("    }\n");
 	}
 	
 	private String incomingTsClient() {

--- a/api/docs/org.jboss.tools.rsp.schema/src/main/resources/client/typescript/src/protocol/generated/incoming.ts
+++ b/api/docs/org.jboss.tools.rsp.schema/src/main/resources/client/typescript/src/protocol/generated/incoming.ts
@@ -78,40 +78,100 @@ export class Incoming {
     onPromptString(listener: (arg: Protocol.StringPrompt) => Promise<string>): void {
         this.connection.onRequest(Messages.Client.PromptStringRequest.type, listener);
     }
+
     onDiscoveryPathAdded(listener: (arg: Protocol.DiscoveryPath) => void): void {
         this.emitter.on('discoveryPathAdded', listener);
     }
+
+    removeOnDiscoveryPathAdded(listener: (arg: Protocol.DiscoveryPath) => void): void {
+        this.emitter.removeListener('discoveryPathAdded', listener);
+    }
+
     onDiscoveryPathRemoved(listener: (arg: Protocol.DiscoveryPath) => void): void {
         this.emitter.on('discoveryPathRemoved', listener);
     }
+
+    removeOnDiscoveryPathRemoved(listener: (arg: Protocol.DiscoveryPath) => void): void {
+        this.emitter.removeListener('discoveryPathRemoved', listener);
+    }
+
     onServerAdded(listener: (arg: Protocol.ServerHandle) => void): void {
         this.emitter.on('serverAdded', listener);
     }
+
+    removeOnServerAdded(listener: (arg: Protocol.ServerHandle) => void): void {
+        this.emitter.removeListener('serverAdded', listener);
+    }
+
     onServerRemoved(listener: (arg: Protocol.ServerHandle) => void): void {
         this.emitter.on('serverRemoved', listener);
     }
+
+    removeOnServerRemoved(listener: (arg: Protocol.ServerHandle) => void): void {
+        this.emitter.removeListener('serverRemoved', listener);
+    }
+
     onServerAttributesChanged(listener: (arg: Protocol.ServerHandle) => void): void {
         this.emitter.on('serverAttributesChanged', listener);
     }
+
+    removeOnServerAttributesChanged(listener: (arg: Protocol.ServerHandle) => void): void {
+        this.emitter.removeListener('serverAttributesChanged', listener);
+    }
+
     onServerStateChanged(listener: (arg: Protocol.ServerState) => void): void {
         this.emitter.on('serverStateChanged', listener);
     }
+
+    removeOnServerStateChanged(listener: (arg: Protocol.ServerState) => void): void {
+        this.emitter.removeListener('serverStateChanged', listener);
+    }
+
     onServerProcessCreated(listener: (arg: Protocol.ServerProcess) => void): void {
         this.emitter.on('serverProcessCreated', listener);
     }
+
+    removeOnServerProcessCreated(listener: (arg: Protocol.ServerProcess) => void): void {
+        this.emitter.removeListener('serverProcessCreated', listener);
+    }
+
     onServerProcessTerminated(listener: (arg: Protocol.ServerProcess) => void): void {
         this.emitter.on('serverProcessTerminated', listener);
     }
+
+    removeOnServerProcessTerminated(listener: (arg: Protocol.ServerProcess) => void): void {
+        this.emitter.removeListener('serverProcessTerminated', listener);
+    }
+
     onServerProcessOutputAppended(listener: (arg: Protocol.ServerProcessOutput) => void): void {
         this.emitter.on('serverProcessOutputAppended', listener);
     }
+
+    removeOnServerProcessOutputAppended(listener: (arg: Protocol.ServerProcessOutput) => void): void {
+        this.emitter.removeListener('serverProcessOutputAppended', listener);
+    }
+
     onJobAdded(listener: (arg: Protocol.JobHandle) => void): void {
         this.emitter.on('jobAdded', listener);
     }
+
+    removeOnJobAdded(listener: (arg: Protocol.JobHandle) => void): void {
+        this.emitter.removeListener('jobAdded', listener);
+    }
+
     onJobRemoved(listener: (arg: Protocol.JobRemoved) => void): void {
         this.emitter.on('jobRemoved', listener);
     }
+
+    removeOnJobRemoved(listener: (arg: Protocol.JobRemoved) => void): void {
+        this.emitter.removeListener('jobRemoved', listener);
+    }
+
     onJobChanged(listener: (arg: Protocol.JobProgress) => void): void {
         this.emitter.on('jobChanged', listener);
+    }
+
+    removeOnJobChanged(listener: (arg: Protocol.JobProgress) => void): void {
+        this.emitter.removeListener('jobChanged', listener);
     }
 }

--- a/api/docs/org.jboss.tools.rsp.schema/src/main/resources/client/typescript/src/protocol/generated/protocol.ts
+++ b/api/docs/org.jboss.tools.rsp.schema/src/main/resources/client/typescript/src/protocol/generated/protocol.ts
@@ -3,7 +3,7 @@
  */
 export namespace Protocol {
     /* tslint:disable */
-    // Generated using typescript-generator version 2.2.413 on 2019-05-09 13:45:23.
+    // Generated using typescript-generator version 2.2.413 on 2019-05-27 17:37:06.
     
     export interface Attribute {
         type: string;

--- a/api/docs/org.jboss.tools.rsp.schema/src/main/resources/schema/typescript/protocol.unified.d.ts
+++ b/api/docs/org.jboss.tools.rsp.schema/src/main/resources/schema/typescript/protocol.unified.d.ts
@@ -1,5 +1,5 @@
 /* tslint:disable */
-// Generated using typescript-generator version 2.2.413 on 2019-05-09 13:45:23.
+// Generated using typescript-generator version 2.2.413 on 2019-05-27 17:37:06.
 
 export interface Attribute {
     type: string;


### PR DESCRIPTION
suggests adding ```Incoming.removeOnXXX``` methods so that removing listeners that were added via ```Incoming.onXXX``` gets obvious (currently there's ```client.removeListener('eventname')```)

see here: https://github.com/redhat-developer/rsp-server/pull/374/files#diff-109dd76b9efb24aca1a1cea945e72cb7R110

fixes #373 