### PR TITLE
Integration tests for app deployment (fixes #162)

### DIFF
--- a/distribution/integration-tests/pom.xml
+++ b/distribution/integration-tests/pom.xml
@@ -23,6 +23,10 @@
 		<server.path>${project.build.directory}/wildfly-${server.version}</server.path>
 		<!-- Sonar report property for code coverage -->
 		<sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+		<!-- Quickstarts properties -->
+		<quickstarts.server>wildfly</quickstarts.server>
+		<quickstarts.url>https://github.com/wildfly/quickstart/archive/16.0.0.Final.zip</quickstarts.url>
+		<quickstarts.dir>quickstart-16.0.0.Final</quickstarts.dir>
 	</properties>
 
 	<name>Runtime Server Protocol : Integration Tests</name>
@@ -39,6 +43,7 @@
 						<server.type.id>${server.type.id}</server.type.id>
 						<server.version>${server.version}</server.version>
 						<server.path>${server.path}</server.path>
+						<quickstarts.server>${quickstarts.server}</quickstarts.server>
 					</systemPropertyVariables>
 				</configuration>
 			</plugin>
@@ -77,6 +82,7 @@
 								<echo>[server.type.id] ${server.type.id}</echo>
 								<echo>[server.version] ${server.version}</echo>
 								<echo>[server.path] ${server.path}</echo>
+								<echo>[quickstarts.server] ${quickstarts.server}</echo>
 							</tasks>
 						</configuration>
 					</execution>
@@ -103,6 +109,48 @@
 						</configuration>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.googlecode.maven-download-plugin</groupId>
+				<artifactId>download-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>download-${quickstarts.dir}</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>wget</goal>
+						</goals>
+						<configuration>
+							<url>${quickstarts.url}</url>
+							<unpack>true</unpack>
+							<outputDirectory>${project.build.directory}</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-invoker-plugin</artifactId>
+			 	<version>3.2.0</version>
+			 	<configuration>
+				 	<cloneProjectsTo>${project.build.directory}/quickstarts</cloneProjectsTo>
+				 	<projectsDirectory>target/${quickstarts.dir}/</projectsDirectory>
+					<pomIncludes>
+						<pomInclude>kitchensink/pom.xml</pomInclude>
+						<pomInclude>kitchensink-ear/pom.xml</pomInclude>
+						<pomInclude>ejb-in-war/pom.xml</pomInclude>
+						<pomInclude>ejb-in-ear/pom.xml</pomInclude>
+					</pomIncludes>
+				</configuration>
+			  	<executions>
+			    	<execution>
+				      	<id>build-quickstart</id>
+				      	<phase>test-compile</phase>
+				      	<goals>
+				        	<goal>install</goal>
+				        	<goal>run</goal>
+				      	</goals>
+			    	</execution>
+			  	</executions>
 			</plugin>
 			<!-- Aggregate coverage report by default -->
 			<plugin>
@@ -148,7 +196,8 @@
 			<id>wildfly-14</id>
 			<activation>
 				<property>
-					<name>wildfly-14</name>
+					<name>wildfly</name>
+					<value>14</value>
 				</property>
 			</activation>
 			<properties>
@@ -163,7 +212,8 @@
 			<id>wildfly-15</id>
 			<activation>
 				<property>
-					<name>wildfly-15</name>
+					<name>wildfly</name>
+					<value>15</value>
 				</property>
 			</activation>
 			<properties>
@@ -178,7 +228,8 @@
 			<id>wildfly-16</id>
 			<activation>
 				<property>
-					<name>wildfly-16</name>
+					<name>wildfly</name>
+					<value>16</value>
 				</property>
 			</activation>
 			<properties>
@@ -187,6 +238,32 @@
 				<server.sha1>b55ed374ab4f8534c2343ac9a283c71fa6d22dfe</server.sha1>
 				<server.type.id>org.jboss.ide.eclipse.as.wildfly.160</server.type.id>
 				<server.version>16.0.0.Final</server.version>
+			</properties>
+		</profile>
+		<profile>
+			<id>wildfly-quickstarts</id>
+			<activation>
+				<property>
+					<name>wildfly</name>
+				</property>
+			</activation>
+			<properties>
+				<quickstarts.server>wildfly</quickstarts.server>
+				<quickstarts.dir>quickstart-16.0.0.Final</quickstarts.dir>
+				<quickstarts.url>https://github.com/wildfly/quickstart/archive/16.0.0.Final.zip</quickstarts.url>
+			</properties>
+		</profile>
+		<profile>
+			<id>eap-quickstarts</id>
+			<activation>
+				<property>
+					<name>eap</name>
+				</property>
+			</activation>
+			<properties>
+				<quickstarts.server>eap</quickstarts.server>
+				<quickstarts.dir>jboss-eap-7.2.1.GA-quickstarts</quickstarts.dir>
+				<quickstarts.url>http://download.eng.brq.redhat.com/released/JBoss-middleware/eap7/7.2.1/jboss-eap-7.2.1-quickstarts.zip</quickstarts.url>
 			</properties>
 		</profile>
 	</profiles>

--- a/distribution/integration-tests/src/test/java/org/jboss/tools/rsp/itests/RSPCase.java
+++ b/distribution/integration-tests/src/test/java/org/jboss/tools/rsp/itests/RSPCase.java
@@ -8,6 +8,8 @@
  ******************************************************************************/
 package org.jboss.tools.rsp.itests;
 
+import static org.jboss.tools.rsp.itests.util.ServerStateUtil.waitForServerState;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.nio.file.Paths;
@@ -15,17 +17,27 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import org.jboss.tools.rsp.api.RSPServer;
+import org.jboss.tools.rsp.api.ServerManagementAPIConstants;
+import org.jboss.tools.rsp.api.dao.DeployableReference;
+import org.jboss.tools.rsp.api.dao.DeployableState;
 import org.jboss.tools.rsp.api.dao.DiscoveryPath;
+import org.jboss.tools.rsp.api.dao.LaunchParameters;
+import org.jboss.tools.rsp.api.dao.PublishServerRequest;
 import org.jboss.tools.rsp.api.dao.ServerAttributes;
 import org.jboss.tools.rsp.api.dao.ServerBean;
 import org.jboss.tools.rsp.api.dao.ServerHandle;
 import org.jboss.tools.rsp.api.dao.ServerType;
+import org.jboss.tools.rsp.api.dao.StartServerResponse;
 import org.jboss.tools.rsp.api.dao.Status;
+import org.jboss.tools.rsp.api.dao.StopServerAttributes;
+import org.jboss.tools.rsp.itests.util.DummyClient;
 import org.jboss.tools.rsp.itests.util.DummyClientLauncher;
 import org.jboss.tools.rsp.itests.util.RSPServerHandler;
 import org.jboss.tools.rsp.itests.util.RSPServerUtility;
+import org.jboss.tools.rsp.itests.util.ServerStateUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -41,6 +53,10 @@ public abstract class RSPCase {
 	protected static String WILDFLY_ROOT;
 	protected static ServerType wildflyType;
 	protected static final String INVALID_PARAM = "Parameter is invalid. It may be null, missing required fields, or unacceptable values.";
+
+	protected static final String MODE_DEBUG = "debug";
+	protected static final String MODE_RUN = "run";
+	protected static final String STATUS_MESSAGE_OK = "ok";
 
 	protected static DummyClientLauncher launcher;
 	protected static RSPServer serverProxy;
@@ -81,6 +97,30 @@ public abstract class RSPCase {
 		RSPServerHandler.restoreBackupData(true);
 	}
 
+	protected void startServer(DummyClient client, String id) throws Exception {
+		Map<String, Object> attr = new HashMap<>();
+		attr.put("server.home.dir", WILDFLY_ROOT);
+		LaunchParameters params = new LaunchParameters(new ServerAttributes(wildflyType.getId(), id, attr), MODE_RUN);
+
+		StartServerResponse response = serverProxy.startServerAsync(params).get();
+
+		assertEquals(0, response.getStatus().getSeverity());
+		assertEquals(STATUS_MESSAGE_OK, response.getStatus().getMessage());
+		ServerStateUtil.waitForServerState(ServerManagementAPIConstants.STATE_STARTED, 10, client);
+	}
+
+	protected void stopServer(DummyClient client, String id) throws Exception {
+		if (client.getStateObject() != null
+				&& client.getStateObject().getState() != ServerManagementAPIConstants.STATE_STOPPED) {
+			Status status = serverProxy.stopServerAsync(new StopServerAttributes(id, true)).get();
+			assertEquals(Status.OK, status.getSeverity());
+			assertEquals(STATUS_MESSAGE_OK, status.getMessage());
+			waitForServerState(ServerManagementAPIConstants.STATE_STOPPED, 10, client);
+		} else {
+			System.out.println("Server is already stopped");
+		}
+	}
+
 	protected Status createServer(String location, String id) throws Exception {
 		ServerBean bean = serverProxy.findServerBeans(new DiscoveryPath(location)).get().get(0);
 		Map<String, Object> attr = new HashMap<>();
@@ -91,13 +131,27 @@ public abstract class RSPCase {
 
 	protected void deleteServer(String id) throws Exception {
 		CompletableFuture<List<ServerHandle>> handles = serverProxy.getServerHandles();
-		ServerHandle handle = handles.get().stream()
-			.filter(server -> id.equals(server.getId()))
-			.findFirst().orElse(null);
+		ServerHandle handle = handles.get().stream().filter(server -> id.equals(server.getId())).findFirst()
+				.orElse(null);
 		if (handle == null) {
 			return;
 		}
 		serverProxy.deleteServer(handle);
+	}
+
+	protected void sendPublishRequest(ServerHandle handle, int publishType)
+			throws InterruptedException, ExecutionException {
+		PublishServerRequest pubReq = new PublishServerRequest(handle, publishType);
+		Status status = serverProxy.publish(pubReq).get();
+		assertEquals("Expected request status is 'ok' but was " + status, Status.OK, status.getSeverity());
+	}
+
+	public DeployableState getDeployableState(DeployableReference reference, List<DeployableState> states) {
+		if (states == null || states.isEmpty()) {
+			return null;
+		}
+
+		return states.stream().filter(state -> reference.equals(state.getReference())).findFirst().orElse(null);
 	}
 
 }

--- a/distribution/integration-tests/src/test/java/org/jboss/tools/rsp/itests/util/DummyClient.java
+++ b/distribution/integration-tests/src/test/java/org/jboss/tools/rsp/itests/util/DummyClient.java
@@ -47,9 +47,4 @@ public class DummyClient extends ServerManagementClientImpl {
     public ServerState getStateObject() {
     	return state;
     }
-    
-    public void clearState() {
-    	this.state = null;
-    	this.stateString = null;
-    }
 }

--- a/distribution/integration-tests/src/test/java/org/jboss/tools/rsp/itests/util/HttpUtility.java
+++ b/distribution/integration-tests/src/test/java/org/jboss/tools/rsp/itests/util/HttpUtility.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2018-2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * All rights reserved. This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * Contributors: Red Hat, Inc.
+ ******************************************************************************/
+package org.jboss.tools.rsp.itests.util;
+
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.logging.Logger;
+
+/**
+ * Http requests utility class.
+ * @author odockal
+ *
+ */
+public class HttpUtility {
+
+	private static Logger log = Logger.getLogger(HttpUtility.class.getName());
+	
+    public static int getHttpStatusCode(String uri) throws IOException {
+    	log.info("URL to check: " + uri);
+    	HttpURLConnection connection = constructHttpRequest(uri, "GET");
+		int responseCode = connection.getResponseCode();
+		connection.disconnect();
+		return responseCode;
+    }
+    
+    public static void waitForUrlEndpoint(URL url, int statusCode, int attempts) throws IOException, InterruptedException {
+    	int tries = 0;
+    	int actualCode = 0;
+    	while(tries++ < attempts) {
+    		actualCode = getHttpStatusCode(url.toString());
+    		if (actualCode == statusCode) {
+    			return;
+    		}
+    		Thread.sleep(1000);
+    	}
+    	fail("Failed to get expected endpoint on url " + url.toString()
+    			+ " to be available with status code " + statusCode + ", code was " + actualCode);
+    }
+    
+    public static HttpURLConnection constructHttpRequest(String uri, String method) throws IOException {
+    	URL url = null;
+    	try {
+			url = new URL(uri);
+		} catch (MalformedURLException e) {
+			fail("Malformed URL: " + uri);
+		}
+    	return setupHttpURLConnection(url, method);
+    }
+    
+    public static HttpURLConnection setupHttpURLConnection(URL url, String method) throws IOException {
+		HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+		connection.setRequestMethod(method);
+		HttpURLConnection.setFollowRedirects(true);
+		connection.setRequestProperty("Content-Type", "application/xml");
+		connection.setRequestProperty("Accept", "application/xml");
+		connection.setReadTimeout(30000);
+		return connection;
+    }
+}

--- a/distribution/integration-tests/src/test/java/org/jboss/tools/rsp/itests/util/ServerStateUtil.java
+++ b/distribution/integration-tests/src/test/java/org/jboss/tools/rsp/itests/util/ServerStateUtil.java
@@ -11,6 +11,11 @@ package org.jboss.tools.rsp.itests.util;
 import org.jboss.tools.rsp.api.ServerManagementAPIConstants;
 import org.jboss.tools.rsp.api.dao.ServerState;
 
+/**
+ * Utility class for server state manipulation.
+ * @author adietish, odockal
+ *
+ */
 public class ServerStateUtil {
 
 	private static final long WAIT_FOR_SERVERSTATE = 3000;
@@ -52,13 +57,33 @@ public class ServerStateUtil {
 			if (s != null) {
 				if (expected == NO_STATE
 						|| expected == s.getState()) {
-					client.clearState();
 					return s;
 				}
 			}
-            System.out.println("Server state: " + ServerStateUtil.toStateString(s));
             Thread.sleep(WAIT_FOR_SERVERSTATE);
         }
         throw new AssertionError("Waiting for server state to change to " + expected + " timed out");
     }
+    
+    public static ServerState waitForDeployables(int attempts, DummyClient client) throws Exception {
+        return waitForDeployablePublishState(NO_STATE, attempts, client);
+    }
+    
+    public static ServerState waitForDeployablePublishState(int expected, int attempts, DummyClient client) throws Exception {
+        int tries = attempts;
+        
+        while(tries > 0) {
+            tries--;
+            ServerState s = client.getStateObject();
+			if (s != null) {
+				if (s.getDeployableStates().size() > 0 && 
+						(expected == s.getDeployableStates().get(0).getPublishState() || expected == NO_STATE)) {
+					return s;
+				}
+			}
+            Thread.sleep(WAIT_FOR_SERVERSTATE);
+        }
+        throw new AssertionError("Waiting for server publish state to change to " + expected + " timed out");
+    }
+    
 }

--- a/distribution/integration-tests/src/test/java/org/jboss/tools/rsp/itests/wildfly/QuickstartsDeploymentTest.java
+++ b/distribution/integration-tests/src/test/java/org/jboss/tools/rsp/itests/wildfly/QuickstartsDeploymentTest.java
@@ -1,0 +1,230 @@
+/*******************************************************************************
+ * Copyright (c) 2018-2019 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * All rights reserved. This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * Contributors: Red Hat, Inc.
+ ******************************************************************************/
+package org.jboss.tools.rsp.itests.wildfly;
+
+import static org.jboss.tools.rsp.itests.util.ServerStateUtil.waitForDeployablePublishState;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import org.jboss.tools.rsp.api.ServerManagementAPIConstants;
+import org.jboss.tools.rsp.api.dao.DeployableReference;
+import org.jboss.tools.rsp.api.dao.DeployableState;
+import org.jboss.tools.rsp.api.dao.ServerDeployableReference;
+import org.jboss.tools.rsp.api.dao.ServerHandle;
+import org.jboss.tools.rsp.api.dao.Status;
+import org.jboss.tools.rsp.itests.RSPCase;
+import org.jboss.tools.rsp.itests.util.DummyClient;
+import org.jboss.tools.rsp.itests.util.HttpUtility;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import net.lingala.zip4j.core.ZipFile;
+import net.lingala.zip4j.exception.ZipException;
+
+/**
+ * Parametrized test class for verification that particular applications in form
+ * of war/ear archives or exploded archives can be deployed on the server.
+ * 
+ * @author odockal
+ *
+ */
+@RunWith(Parameterized.class)
+public class QuickstartsDeploymentTest extends RSPCase {
+
+	private final DummyClient client = launcher.getClient();
+
+	private static Logger log = Logger.getLogger(QuickstartsDeploymentTest.class.getName());
+
+	private static final List<String> projects = Arrays.asList("kitchensink", "kitchensink-ear", "ejb-in-war",
+			"ejb-in-ear");
+
+	private static final List<String> deploymentTypes = Arrays.asList("war", "exploded");
+
+	private static final Path QUICKSTARTS_ROOT = Paths.get(getProperty("user.dir"), "target", "quickstarts");
+
+	private static final Map<String, String> deployments = deploymentsmapping();
+
+	private static final String QUICKSTARTS_SERVER = getProperty("quickstarts.server");
+
+	private static String SERVER_ID = "wildfly";
+
+	private URL url;
+
+	private String project;
+	private String deploymentType;
+	private Path projectPath;
+	private ServerHandle handle;
+	private DeployableReference reference;
+
+	@Parameters(name = "{0} {1} {2}")
+	public static Collection<String[]> data() {
+		return projects.stream().flatMap(project -> deploymentTypes.stream().map(type -> {
+			return new String[] { QUICKSTARTS_SERVER, project, type };
+		})).collect(Collectors.toList());
+	}
+
+	@BeforeClass
+	public static void configureSkippingTests() {
+		// Skip test if requirements are not fulfilled
+		assumeTrue("Could not find quickstarts project on the path: " + QUICKSTARTS_ROOT.toString(),
+				Files.exists(QUICKSTARTS_ROOT, LinkOption.NOFOLLOW_LINKS));
+	}
+
+	private static Map<String, String> deploymentsmapping() {
+		Map<String, String> map = new HashMap<>();
+		map.put("kitchensink-ear", "kitchensink-ear-web");
+		return map;
+	}
+
+	public QuickstartsDeploymentTest(String server, String project, String type) {
+		this.project = project;
+		this.deploymentType = type;
+		setProjectPath();
+	}
+
+	@Before
+	public void before() throws Exception {
+		createServer(WILDFLY_ROOT, SERVER_ID);
+		startServer(client, SERVER_ID);
+		handle = new ServerHandle(SERVER_ID, wildflyType);
+		reference = new DeployableReference(projectPath.toFile().getName(), projectPath.toFile().getAbsolutePath());
+		url = new URL("http://localhost:8080" + "/" + deployments.getOrDefault(this.project, this.project));
+	}
+
+	@After
+	public void after() throws Exception {
+		stopServer(client, SERVER_ID);
+		deleteServer(SERVER_ID);
+	}
+
+	@Test
+	public void testAppDeploymentToServer() throws Exception {
+		// Verify project path
+		assertTrue("File " + projectPath + " does not exist", Files.exists(projectPath, LinkOption.NOFOLLOW_LINKS));
+		// No deployable avaiable at the moment
+		assertTrue(serverProxy.getDeployables(handle).get().isEmpty());
+		serverProxy.addDeployable(new ServerDeployableReference(handle, reference));
+		waitForDeployablePublishState(ServerManagementAPIConstants.PUBLISH_STATE_ADD, 10, client);
+		verifyURL(url.toString(), 404);
+
+		// Deployable available, but not deployed yet until publish full request send to
+		// the server
+		DeployableState state = getDeployableStateByReference(handle, reference);
+		assertNotNull("Deployable reference was not found", state);
+		assertDeployableReference(state);
+		verifyURL(url.toString(), 404);
+
+		// send publish request with publish full kind
+		sendPublishRequest(handle, ServerManagementAPIConstants.PUBLISH_FULL);
+
+		// check for the publishing is done, then it requires no publish change
+		waitForDeployablePublishState(ServerManagementAPIConstants.PUBLISH_STATE_NONE, 10, client);
+		state = getDeployableStateByReference(handle, reference);
+		assertNotNull("Deployable reference was not found", state);
+		assertDeployableReference(state);
+		// even though publishing is done, app is not yet deployed, thus waiting takes
+		// place
+		HttpUtility.waitForUrlEndpoint(url, 200, 30);
+		verifyURL(url.toString(), 200);
+
+		// Remove deployment
+		Status statusRemove = serverProxy.removeDeployable(new ServerDeployableReference(handle, reference)).get();
+		assertEquals("Publish request status OK check failed, was: " + statusRemove.getMessage(), Status.OK,
+				statusRemove.getSeverity());
+		state = getDeployableStateByReference(handle, reference);
+		// Deployable state of the depl. is still present
+		assertNotNull("Deployable reference was not found", state);
+		assertDeployableReference(state);
+		verifyURL(url.toString(), 200);
+
+		// Another publish full request must be sent
+		sendPublishRequest(handle, ServerManagementAPIConstants.PUBLISH_FULL);
+
+		// Deployment is no more
+		assertTrue(serverProxy.getDeployables(handle).get().isEmpty());
+		state = getDeployableStateByReference(handle, reference);
+		assertNull("Deployable reference was still found", state);
+		HttpUtility.waitForUrlEndpoint(url, 404, 30);
+		verifyURL(url.toString(), 404);
+	}
+
+	private DeployableState getDeployableStateByReference(ServerHandle handle, DeployableReference reference) {
+		List<DeployableState> deployables = new ArrayList<>();
+		try {
+			deployables = serverProxy.getDeployables(handle).get();
+		} catch (InterruptedException | ExecutionException e) {
+			log.log(Level.SEVERE, "Failed to get deployables", e);
+			e.printStackTrace();
+		}
+		return deployables.stream().filter(x -> x.getReference().equals(reference)).findFirst().orElse(null);
+	}
+
+	private void assertDeployableReference(DeployableState state) {
+		assertEquals(projectPath.toFile().getName(), state.getReference().getLabel());
+		assertEquals(projectPath.toFile().getAbsolutePath(), state.getReference().getPath());
+	}
+
+	private void verifyURL(String uri, int expectedStatusCode) throws IOException {
+		assertEquals("Http response status code for " + uri + " does not match", expectedStatusCode,
+				HttpUtility.getHttpStatusCode(uri));
+	}
+
+	private void setProjectPath() {
+		String projectRelativePath = this.project;
+		if (this.project.contains("ear")) {
+			projectRelativePath += "/ear/target/" + this.project + ".ear";
+		} else {
+			projectRelativePath += "/target/" + this.project + ".war";
+		}
+		this.projectPath = Paths.get(QUICKSTARTS_ROOT.toString(), projectRelativePath);
+
+		if (deploymentType.equals("exploded")) {
+			try {
+				this.projectPath = extractWARExploded(projectPath);
+			} catch (ZipException e) {
+				e.printStackTrace();
+				log.log(Level.SEVERE, "Failed to extract archive " + projectPath, e);
+			}
+		}
+	}
+
+	private Path extractWARExploded(Path warFile) throws ZipException {
+		ZipFile file = new ZipFile(warFile.toFile());
+		Path exploded = Paths.get(warFile.getParent().toFile().toString() + "/exploded/" + warFile.toFile().getName());
+		log.log(Level.INFO, "Extracting " + warFile);
+		file.extractAll(exploded.toString());
+		log.log(Level.INFO, "Extracted to " + exploded);
+		return exploded;
+	}
+}

--- a/distribution/integration-tests/src/test/java/org/jboss/tools/rsp/itests/wildfly/WildFlyLaunchingTest.java
+++ b/distribution/integration-tests/src/test/java/org/jboss/tools/rsp/itests/wildfly/WildFlyLaunchingTest.java
@@ -41,10 +41,6 @@ import org.junit.Test;
  * @author jrichter
  */
 public class WildFlyLaunchingTest extends RSPCase {
-    
-    private static final String MODE_DEBUG = "debug";
-	private static final String MODE_RUN = "run";
-	private static final String STATUS_MESSAGE_OK = "ok";
 
 	private final DummyClient client = launcher.getClient();
 


### PR DESCRIPTION
   - refactored Publishing testing
   - added profiles for downloading wildfly and eap quickstarts
   - added WildFlyDeploymentTest class
   - small itests refactoring
   - automated build of downloaded quickstarts
   - wildfly quickstarts are use in itests in jenkinsfile

Signed-off-by: Ondrej Dockal <odockal@redhat.com>