### PR TITLE
Wrong response for Crc Setup action

### DIFF
--- a/runtimes/bundles/org.jboss.tools.rsp.server.minishift/src/main/java/org/jboss/tools/rsp/server/minishift/servertype/impl/CRCServerDelegate.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.minishift/src/main/java/org/jboss/tools/rsp/server/minishift/servertype/impl/CRCServerDelegate.java
@@ -5,9 +5,11 @@ import java.util.concurrent.ExecutionException;
 
 import org.jboss.tools.rsp.api.RSPClient;
 import org.jboss.tools.rsp.api.dao.CommandLineDetails;
+import org.jboss.tools.rsp.api.dao.ServerActionRequest;
 import org.jboss.tools.rsp.api.dao.ServerActionWorkflow;
 import org.jboss.tools.rsp.api.dao.StartServerResponse;
 import org.jboss.tools.rsp.api.dao.StringPrompt;
+import org.jboss.tools.rsp.api.dao.WorkflowResponse;
 import org.jboss.tools.rsp.eclipse.core.runtime.CoreException;
 import org.jboss.tools.rsp.eclipse.core.runtime.IStatus;
 import org.jboss.tools.rsp.eclipse.core.runtime.Status;
@@ -159,5 +161,13 @@ public class CRCServerDelegate extends MinishiftServerDelegate {
 		
 		return null;
 		
+	}
+	
+	@Override
+	public WorkflowResponse executeServerAction(ServerActionRequest req) {
+		if( req != null && SetupCRCActionHandler.ACTION_SETUP_CRC_ID.equals(req.getActionId() )) {
+			return new SetupCRCActionHandler(this).handle(req);
+		}
+		return super.executeServerAction(req);
 	}
 }

--- a/runtimes/bundles/org.jboss.tools.rsp.server.minishift/src/main/java/org/jboss/tools/rsp/server/minishift/servertype/impl/SetupCRCActionHandler.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.minishift/src/main/java/org/jboss/tools/rsp/server/minishift/servertype/impl/SetupCRCActionHandler.java
@@ -15,17 +15,19 @@ import java.util.Map;
 
 import org.jboss.tools.rsp.api.DefaultServerAttributes;
 import org.jboss.tools.rsp.api.ServerManagementAPIConstants;
+import org.jboss.tools.rsp.api.dao.ServerActionRequest;
 import org.jboss.tools.rsp.api.dao.ServerActionWorkflow;
 import org.jboss.tools.rsp.api.dao.WorkflowResponse;
 import org.jboss.tools.rsp.api.dao.WorkflowResponseItem;
 import org.jboss.tools.rsp.eclipse.core.runtime.IStatus;
 import org.jboss.tools.rsp.eclipse.core.runtime.Status;
 import org.jboss.tools.rsp.server.minishift.impl.Activator;
+import org.jboss.tools.rsp.server.model.AbstractServerDelegate;
 import org.jboss.tools.rsp.server.spi.util.StatusConverter;
 
 public class SetupCRCActionHandler {
 	
-	private static final String ACTION_SETUP_CRC_ID = "CRCServerDelegate.setupCRC";
+	public static final String ACTION_SETUP_CRC_ID = "CRCServerDelegate.setupCRC";
 	private static final String ACTION_SETUP_CRC_LABEL = "Run setup-crc";	
 
 	public static final ServerActionWorkflow getInitialWorkflow(CRCServerDelegate crcServerDelegate) {
@@ -60,5 +62,9 @@ public class SetupCRCActionHandler {
 		workflow.setStatus(StatusConverter.convert(
 				new Status(IStatus.OK, Activator.BUNDLE_ID, ACTION_SETUP_CRC_LABEL)));
 		return action;
+	}
+	
+	public WorkflowResponse handle(ServerActionRequest req) {
+		return null;
 	}
 }

--- a/runtimes/bundles/org.jboss.tools.rsp.server.minishift/src/main/java/org/jboss/tools/rsp/server/minishift/servertype/impl/SetupCRCActionHandler.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.minishift/src/main/java/org/jboss/tools/rsp/server/minishift/servertype/impl/SetupCRCActionHandler.java
@@ -22,7 +22,6 @@ import org.jboss.tools.rsp.api.dao.WorkflowResponseItem;
 import org.jboss.tools.rsp.eclipse.core.runtime.IStatus;
 import org.jboss.tools.rsp.eclipse.core.runtime.Status;
 import org.jboss.tools.rsp.server.minishift.impl.Activator;
-import org.jboss.tools.rsp.server.model.AbstractServerDelegate;
 import org.jboss.tools.rsp.server.spi.util.StatusConverter;
 
 public class SetupCRCActionHandler {


### PR DESCRIPTION
This is based on an issue found in the ui https://github.com/redhat-developer/vscode-rsp-ui/issues/95 . Basically the command is executed in the terminal of vscode so the server doesn't need to do anything when the executeServerAction is called. It's like the edit configuration action in wildfly.