### PR TITLE
fix error with vm.install.path property (#589)

### DIFF
--- a/framework/tests/org.jboss.tools.rsp.server.test/src/main/java/org/jboss/tools/rsp/server/wildfly/test/servertype/JBossVMRegistryDiscoveryTest.java
+++ b/framework/tests/org.jboss.tools.rsp.server.test/src/main/java/org/jboss/tools/rsp/server/wildfly/test/servertype/JBossVMRegistryDiscoveryTest.java
@@ -74,7 +74,9 @@ public class JBossVMRegistryDiscoveryTest {
 		String home = System.getProperty("java.home");
 		assertNotNull(discovery.findVMInstall(home));
 		registry.removeVMInstall(registry.getDefaultVMInstall());
-		assertNull(discovery.findVMInstall(home));
+		assertThat(registry.getVMs()).hasSize(0);
+		assertNotNull(discovery.findVMInstall(home));
+		assertThat(registry.getVMs()).hasSize(1);
 	}
 	
 	@Test

--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/JBossVMRegistryDiscovery.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/JBossVMRegistryDiscovery.java
@@ -45,7 +45,9 @@ public class JBossVMRegistryDiscovery {
 		if( vmPath == null ) {
 			vmi = reg.getDefaultVMInstall();
 		} else {
-			vmi = reg.findVMInstall(new File(vmPath));
+			if (ensureVMInstallAdded(vmPath, reg)) {
+				vmi = reg.findVMInstall(new File(vmPath));
+			}			
 		}
 		return vmi;
 	}


### PR DESCRIPTION
it resolves #589 

@odockal the problem comes when you install the latest version of vscode java 0.65.0 that forces users to switch to java 11 ( https://marketplace.visualstudio.com/items?itemName=redhat.java ). To install it you need to have vscode 1.47. 
When i was using 1.46 it only installed vscode java 0.64.1 (don't know why).