### PR TITLE
Fix violations of Sonar rule 2755

### DIFF
--- a/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java
+++ b/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/internal/launching/java/util/LaunchingSupportUtils.java
@@ -7,6 +7,7 @@
  * Contributors: Red Hat, Inc.
  ******************************************************************************/
 package org.jboss.tools.rsp.internal.launching.java.util;
+import javax.xml.XMLConstants;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -82,7 +83,7 @@ public class LaunchingSupportUtils {
 	private static DocumentBuilder getParser() throws CoreException {
 		if (fgXMLParser == null) {
 			try {
-				fgXMLParser = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+				fgXMLParser = createDocumentBuilderFactory().newDocumentBuilder();
 				fgXMLParser.setErrorHandler(new DefaultHandler());
 			} catch (ParserConfigurationException e) {
 				abort(LaunchingPlugin_34, e);
@@ -347,5 +348,12 @@ public class LaunchingSupportUtils {
 	protected static void abort(String message, Throwable exception, int code) throws CoreException {
 		throw new CoreException(new Status(IStatus.ERROR, IVMInstallChangedListener.LAUNCHING_ID_PLUGIN,
 				code, message, exception));
+	}
+
+	private static DocumentBuilderFactory createDocumentBuilderFactory() {
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		return factory;
 	}
 }

--- a/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java
+++ b/framework/bundles/org.jboss.tools.rsp.launching/src/main/java/org/jboss/tools/rsp/launching/memento/XMLMemento.java
@@ -89,7 +89,7 @@ public final class XMLMemento implements IMemento {
 		
 		Document document = null;
 		try {	
-			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			DocumentBuilderFactory factory = createDocumentBuilderFactory();
 			DocumentBuilder parser = factory.newDocumentBuilder();
 			document = parser.parse(new InputSource(in));
 			Node node = document.getFirstChild();
@@ -126,7 +126,7 @@ public final class XMLMemento implements IMemento {
 	public static XMLMemento createWriteRoot(String type) {
 		Document document;
 		try {
-			document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+			document = createDocumentBuilderFactory().newDocumentBuilder().newDocument();
 			Element element = document.createElement(type);
 			document.appendChild(element);
 			return new XMLMemento(document, element);
@@ -348,7 +348,7 @@ public final class XMLMemento implements IMemento {
 		Result result = new StreamResult(os);
 		Source source = new DOMSource(factory);
 		try {
-			TransformerFactory factory = TransformerFactory.newInstance();
+			TransformerFactory factory = createTransformerFactory();
 			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 			Transformer transformer = factory.newTransformer();
 			transformer.setOutputProperty(OutputKeys.INDENT, "yes"); //$NON-NLS-1$
@@ -435,5 +435,19 @@ public final class XMLMemento implements IMemento {
 			return textNode.getData();
 		}
 		return ""; //$NON-NLS-1$
+	}
+
+	private static DocumentBuilderFactory createDocumentBuilderFactory() {
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		return factory;
+	}
+
+	private static TransformerFactory createTransformerFactory() {
+		TransformerFactory factory = TransformerFactory.newInstance();
+		factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+		return factory;
 	}
 }


### PR DESCRIPTION
Hi,

This PR fixes violations of [Sonar rule 2755: "XML parsers should not be vulnerable to XXE attacks"](https://rules.sonarsource.com/java/RSPEC-2755). It's related to issue #317.

* Violations before PR: 4
* Violations after PR: 0

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2755](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#xml-parsers-should-not-be-vulnerable-to-xxe-attacks-sonar-rule-2755).

Ps. I'm not a bot, so please do treat this like any other PR in regards to providing feedback :)