### PR TITLE
Add workflow to automate creation of new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Generate plugin archive for new release
+on: [workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+          architecture: x64
+      - name: Build & Verify using Maven
+        run: mvn clean verify -DskipTest=true
+      - name: Get current pom version
+        id: pom-version
+        run: |
+          echo ::set-output name=version::$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.pom-version.outputs.version }}
+          release_name: ${{ steps.pom-version.outputs.version }}
+          body: Release ${{ steps.pom-version.outputs.version }}


### PR DESCRIPTION
This workflow can be run manually when a new release should be created. It creates a new release entry and attach the source code to it. No input required as it takes the version from pom.xml.

Example -> https://github.com/lstocchi/rsp-server/releases/tag/0.25.2.Final