### PR TITLE
Fixes #698 - wrong environment passed in during debug launches

### DIFF
--- a/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/eclipse/jdt/internal/launching/StandardVMDebugger.java
+++ b/framework/bundles/org.jboss.tools.rsp.launching.java/src/main/java/org/jboss/tools/rsp/eclipse/jdt/internal/launching/StandardVMDebugger.java
@@ -157,9 +157,9 @@ public class StandardVMDebugger extends StandardVMRunner {
 		//format: <jdk path>/jre/bin
 		String[] envp = prependJREPath(config.getEnvironment(), new Path(program));
 
-		String[] newenvp = checkClasspath(arguments, cp, envp);
-		if(newenvp != null) {
-			envp = newenvp;
+		String[] tmpEnvp = checkClasspath(arguments, cp, envp);
+		if(tmpEnvp != null) {
+			envp = tmpEnvp;
 			arguments.remove(cpidx);
 			arguments.remove(cpidx);
 		}
@@ -181,7 +181,7 @@ public class StandardVMDebugger extends StandardVMRunner {
 		subMonitor.worked(1);
 		subMonitor.subTask(StandardVMDebugger_Starting_virtual_machine____4);
 		Map<String,String> debugFlagMap = generateDebugFlagMap(transport, server, suspend, host, port);
-		return new LaunchingCommandLineDetails(cmdLine, wd, newenvp, debugFlagMap);
+		return new LaunchingCommandLineDetails(cmdLine, wd, envp, debugFlagMap);
 	}
 	
 	


### PR DESCRIPTION
Wrong environment being passed in. Sad. 