### PR TITLE
Add WildFly 35+ and 38+ server type support

### DIFF
--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/beans/impl/IServerConstants.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/beans/impl/IServerConstants.java
@@ -48,6 +48,8 @@ public interface IServerConstants {
 	public static final String SERVER_WILDFLY_230 = "org.jboss.ide.eclipse.as.wildfly.230"; //$NON-NLS-1$
 	public static final String SERVER_WILDFLY_240 = "org.jboss.ide.eclipse.as.wildfly.240"; //$NON-NLS-1$
 	public static final String SERVER_WILDFLY_270 = "org.jboss.ide.eclipse.as.wildfly.270"; //$NON-NLS-1$
+	public static final String SERVER_WILDFLY_350 = "org.jboss.ide.eclipse.as.wildfly.350"; //$NON-NLS-1$
+	public static final String SERVER_WILDFLY_380 = "org.jboss.ide.eclipse.as.wildfly.380"; //$NON-NLS-1$
 	// NEW_SERVER_ADAPTER
 	
 	public static final String SERVER_EAP_43 = "org.jboss.ide.eclipse.as.eap.43"; //$NON-NLS-1$
@@ -67,12 +69,13 @@ public interface IServerConstants {
 			SERVER_AS_60,SERVER_AS_70,SERVER_AS_71,
 			SERVER_WILDFLY_80,SERVER_WILDFLY_90,SERVER_WILDFLY_100,
 			SERVER_WILDFLY_110,SERVER_WILDFLY_120,SERVER_WILDFLY_130,
-			SERVER_WILDFLY_140, SERVER_WILDFLY_150, SERVER_WILDFLY_160, 
+			SERVER_WILDFLY_140, SERVER_WILDFLY_150, SERVER_WILDFLY_160,
 			SERVER_WILDFLY_170, SERVER_WILDFLY_180,SERVER_WILDFLY_190,
 			SERVER_WILDFLY_200,SERVER_WILDFLY_210,SERVER_WILDFLY_220,
 			SERVER_WILDFLY_230,SERVER_WILDFLY_240,SERVER_WILDFLY_270,
-			SERVER_EAP_43,SERVER_EAP_50,SERVER_EAP_60, SERVER_EAP_61, 
-			SERVER_EAP_70, SERVER_EAP_71, SERVER_EAP_72, 
+			SERVER_WILDFLY_350,SERVER_WILDFLY_380,
+			SERVER_EAP_43,SERVER_EAP_50,SERVER_EAP_60, SERVER_EAP_61,
+			SERVER_EAP_70, SERVER_EAP_71, SERVER_EAP_72,
 			SERVER_EAP_73, SERVER_EAP_74, SERVER_EAP_80
 		};
 		// NEW_SERVER_ADAPTER Add the new server id above this line
@@ -112,6 +115,8 @@ public interface IServerConstants {
 	public static final String RUNTIME_WILDFLY_230 = "org.jboss.ide.eclipse.as.runtime.wildfly.230"; //$NON-NLS-1$
 	public static final String RUNTIME_WILDFLY_240 = "org.jboss.ide.eclipse.as.runtime.wildfly.240"; //$NON-NLS-1$
 	public static final String RUNTIME_WILDFLY_270 = "org.jboss.ide.eclipse.as.runtime.wildfly.270"; //$NON-NLS-1$
+	public static final String RUNTIME_WILDFLY_350 = "org.jboss.ide.eclipse.as.runtime.wildfly.350"; //$NON-NLS-1$
+	public static final String RUNTIME_WILDFLY_380 = "org.jboss.ide.eclipse.as.runtime.wildfly.380"; //$NON-NLS-1$
 	// NEW_SERVER_ADAPTER
 	public static final String RUNTIME_EAP_43 = "org.jboss.ide.eclipse.as.runtime.eap.43"; //$NON-NLS-1$
 	public static final String RUNTIME_EAP_50 = "org.jboss.ide.eclipse.as.runtime.eap.50"; //$NON-NLS-1$
@@ -155,6 +160,8 @@ public interface IServerConstants {
 		myMap.put(RUNTIME_WILDFLY_230, SERVER_WILDFLY_230);
 		myMap.put(RUNTIME_WILDFLY_240, SERVER_WILDFLY_240);
 		myMap.put(RUNTIME_WILDFLY_270, SERVER_WILDFLY_270);
+		myMap.put(RUNTIME_WILDFLY_350, SERVER_WILDFLY_350);
+		myMap.put(RUNTIME_WILDFLY_380, SERVER_WILDFLY_380);
 		myMap.put(RUNTIME_EAP_43, SERVER_EAP_43);
 		myMap.put(RUNTIME_EAP_50, SERVER_EAP_50);
 		myMap.put(RUNTIME_EAP_60, SERVER_EAP_60);

--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/impl/ExtensionHandler.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/impl/ExtensionHandler.java
@@ -27,6 +27,8 @@ public class ExtensionHandler {
 
 	private static final IServerType[] TYPES = {
 			// NEW_SERVER_ADAPTER
+			WildFlyServerTypes.WF38_SERVER_TYPE,
+			WildFlyServerTypes.WF35_SERVER_TYPE,
 			WildFlyServerTypes.WF27_SERVER_TYPE,
 			WildFlyServerTypes.WF24_SERVER_TYPE,
 			WildFlyServerTypes.WF23_SERVER_TYPE,

--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/impl/JBossServerBeanTypeProvider.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/impl/JBossServerBeanTypeProvider.java
@@ -174,6 +174,18 @@ public class JBossServerBeanTypeProvider implements IServerBeanTypeProvider, IJB
 	public static final ServerBeanTypeWildflyPlus WILDFLY270_WEB = new ServerBeanTypeWildflyPlus(
 			ID_WILDFLY_WEB, NAME_WILDFLY, AS7_MODULE_LAYERED_SERVER_MAIN,
 			true, 27, IServerConstants.SERVER_WILDFLY_270);
+	public static final ServerBeanTypeWildflyPlus WILDFLY350 = new ServerBeanTypeWildflyPlus(
+			ID_WILDFLY, NAME_WILDFLY, AS7_MODULE_LAYERED_SERVER_MAIN,
+			false, 35, IServerConstants.SERVER_WILDFLY_350);
+	public static final ServerBeanTypeWildflyPlus WILDFLY350_WEB = new ServerBeanTypeWildflyPlus(
+			ID_WILDFLY_WEB, NAME_WILDFLY, AS7_MODULE_LAYERED_SERVER_MAIN,
+			true, 35, IServerConstants.SERVER_WILDFLY_350);
+	public static final ServerBeanTypeWildflyPlus WILDFLY380 = new ServerBeanTypeWildflyPlus(
+			ID_WILDFLY, NAME_WILDFLY, AS7_MODULE_LAYERED_SERVER_MAIN,
+			false, 38, IServerConstants.SERVER_WILDFLY_380);
+	public static final ServerBeanTypeWildflyPlus WILDFLY380_WEB = new ServerBeanTypeWildflyPlus(
+			ID_WILDFLY_WEB, NAME_WILDFLY, AS7_MODULE_LAYERED_SERVER_MAIN,
+			true, 38, IServerConstants.SERVER_WILDFLY_380);
 
 	// NEW_SERVER_ADAPTER
 
@@ -228,6 +240,8 @@ public class JBossServerBeanTypeProvider implements IServerBeanTypeProvider, IJB
 		WILDFLY230, WILDFLY230_WEB,
 		WILDFLY240, WILDFLY240_WEB,
 		WILDFLY270, WILDFLY270_WEB,
+		WILDFLY350, WILDFLY350_WEB,
+		WILDFLY380, WILDFLY380_WEB,
 		WILDFLY80, 
 		FSW6, EAP61, SOA6, JPP61,  DV6, 
 		UNKNOWN_AS72_PRODUCT,

--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/capabilities/ExtendedServerPropertiesAdapterFactory.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/capabilities/ExtendedServerPropertiesAdapterFactory.java
@@ -28,6 +28,8 @@ import org.jboss.tools.rsp.server.wildfly.servertype.capabilities.WildFlyExtende
 import org.jboss.tools.rsp.server.wildfly.servertype.capabilities.WildFlyExtendedProperties.Wildfly230ExtendedProperties;
 import org.jboss.tools.rsp.server.wildfly.servertype.capabilities.WildFlyExtendedProperties.Wildfly240ExtendedProperties;
 import org.jboss.tools.rsp.server.wildfly.servertype.capabilities.WildFlyExtendedProperties.Wildfly270ExtendedProperties;
+import org.jboss.tools.rsp.server.wildfly.servertype.capabilities.WildFlyExtendedProperties.Wildfly350ExtendedProperties;
+import org.jboss.tools.rsp.server.wildfly.servertype.capabilities.WildFlyExtendedProperties.Wildfly380ExtendedProperties;
 import org.jboss.tools.rsp.server.wildfly.servertype.capabilities.WildFlyExtendedProperties.Wildfly80ExtendedProperties;
 import org.jboss.tools.rsp.server.wildfly.servertype.capabilities.WildFlyExtendedProperties.Wildfly90ExtendedProperties;
 
@@ -105,6 +107,10 @@ public class ExtendedServerPropertiesAdapterFactory implements IServerConstants 
 			return new Wildfly240ExtendedProperties(s);
 		case SERVER_WILDFLY_270:
 			return new Wildfly270ExtendedProperties(s);
+		case SERVER_WILDFLY_350:
+			return new Wildfly350ExtendedProperties(s);
+		case SERVER_WILDFLY_380:
+			return new Wildfly380ExtendedProperties(s);
 		// NEW_SERVER_ADAPTER
 		default:
 			return null;

--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/capabilities/WildFlyExtendedProperties.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/capabilities/WildFlyExtendedProperties.java
@@ -112,5 +112,15 @@ public class WildFlyExtendedProperties {
 			super("27.0", "11", "21.", HTTP_REMOTING_JMX_NEW, new Wildfly110DefaultLaunchArguments(server), server);
 		}
 	}
-	// NEW_SERVER_ADAPTER 
+	public static class Wildfly350ExtendedProperties extends AbstractWildflyExtendedProperties {
+		public Wildfly350ExtendedProperties(IServer server) {
+			super("35.0", "17", "21.", HTTP_REMOTING_JMX_NEW, new Wildfly110DefaultLaunchArguments(server), server);
+		}
+	}
+	public static class Wildfly380ExtendedProperties extends AbstractWildflyExtendedProperties {
+		public Wildfly380ExtendedProperties(IServer server) {
+			super("38.0", "17", "25.", HTTP_REMOTING_JMX_NEW, new Wildfly110DefaultLaunchArguments(server), server);
+		}
+	}
+	// NEW_SERVER_ADAPTER
 }

--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/impl/ServerTypeStringConstants.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/impl/ServerTypeStringConstants.java
@@ -11,7 +11,15 @@ package org.jboss.tools.rsp.server.wildfly.servertype.impl;
 import org.jboss.tools.rsp.server.wildfly.beans.impl.IServerConstants;
 
 public interface ServerTypeStringConstants {
-	// NEW_SERVER_ADAPTER 
+	// NEW_SERVER_ADAPTER
+	public static final String WF38_ID = IServerConstants.SERVER_WILDFLY_380;
+	public static final String WF38_NAME = "WildFly 38+";
+	public static final String WF38_DESC = "A server adapter capable of discovering and controlling a WildFly 38.x runtime instance.";
+
+	public static final String WF35_ID = IServerConstants.SERVER_WILDFLY_350;
+	public static final String WF35_NAME = "WildFly 35+";
+	public static final String WF35_DESC = "A server adapter capable of discovering and controlling a WildFly 35.x runtime instance.";
+
 	public static final String WF27_ID = IServerConstants.SERVER_WILDFLY_270;
 	public static final String WF27_NAME = "WildFly 27+";
 	public static final String WF27_DESC = "A server adapter capable of discovering and controlling a WildFly 27.x runtime instance.";

--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/impl/WildFlyServerTypes.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/impl/WildFlyServerTypes.java
@@ -13,7 +13,11 @@ import org.jboss.tools.rsp.server.wildfly.servertype.EapXpServerType;
 
 public class WildFlyServerTypes implements ServerTypeStringConstants{
 	// NEW_SERVER_ADAPTER
-	public static final BaseJBossServerType WF27_SERVER_TYPE = 
+	public static final BaseJBossServerType WF38_SERVER_TYPE =
+			new WildFlyServerType(WF38_ID, WF38_NAME, WF38_DESC);
+	public static final BaseJBossServerType WF35_SERVER_TYPE =
+			new WildFlyServerType(WF35_ID, WF35_NAME, WF35_DESC);
+	public static final BaseJBossServerType WF27_SERVER_TYPE =
 			new WildFlyServerType(WF27_ID, WF27_NAME, WF27_DESC);
 	public static final BaseJBossServerType WF24_SERVER_TYPE = 
 			new WildFlyServerType(WF24_ID, WF24_NAME, WF24_DESC);

--- a/runtimes/tests/org.jboss.tools.rsp.server.wildfly.test/src/main/java/org/jboss/tools/rsp/server/wildfly/test/beans/JBossServerBeanLoaderTest.java
+++ b/runtimes/tests/org.jboss.tools.rsp.server.wildfly.test/src/main/java/org/jboss/tools/rsp/server/wildfly/test/beans/JBossServerBeanLoaderTest.java
@@ -93,6 +93,8 @@ public class JBossServerBeanLoaderTest extends TestCase {
 		expected.put(IServerConstants.SERVER_WILDFLY_230, new Data(JBossServerBeanTypeProvider.WILDFLY230, "23.0."));
 		expected.put(IServerConstants.SERVER_WILDFLY_240, new Data(JBossServerBeanTypeProvider.WILDFLY240, "24.0."));
 		expected.put(IServerConstants.SERVER_WILDFLY_270, new Data(JBossServerBeanTypeProvider.WILDFLY270, "27.0."));
+		expected.put(IServerConstants.SERVER_WILDFLY_350, new Data(JBossServerBeanTypeProvider.WILDFLY350, "35.0."));
+		expected.put(IServerConstants.SERVER_WILDFLY_380, new Data(JBossServerBeanTypeProvider.WILDFLY380, "38.0."));
 		expected.put(IServerConstants.SERVER_EAP_43, new Data(JBossServerBeanTypeProvider.EAP_STD, "4.3."));
 		expected.put(IServerConstants.SERVER_EAP_50, new Data(JBossServerBeanTypeProvider.EAP_STD, "5.1."));
 		expected.put(IServerConstants.SERVER_EAP_60, new Data(JBossServerBeanTypeProvider.EAP6, "6.0."));

--- a/runtimes/tests/org.jboss.tools.rsp.server.wildfly.test/src/main/java/org/jboss/tools/rsp/server/wildfly/test/beans/MockServerCreationUtilities.java
+++ b/runtimes/tests/org.jboss.tools.rsp.server.wildfly.test/src/main/java/org/jboss/tools/rsp/server/wildfly/test/beans/MockServerCreationUtilities.java
@@ -136,6 +136,8 @@ public class MockServerCreationUtilities extends Assert {
 		asSystemJar.put(IServerConstants.SERVER_WILDFLY_230, wildfly_20_0_jar);
 		asSystemJar.put(IServerConstants.SERVER_WILDFLY_240, wildfly_20_0_jar);
 		asSystemJar.put(IServerConstants.SERVER_WILDFLY_270, wildfly_20_0_jar);
+		asSystemJar.put(IServerConstants.SERVER_WILDFLY_350, wildfly_20_0_jar);
+		asSystemJar.put(IServerConstants.SERVER_WILDFLY_380, wildfly_20_0_jar);
 		asSystemJar.put(IServerConstants.SERVER_EAP_43, twiddle_eap_4_3);
 		asSystemJar.put(IServerConstants.SERVER_EAP_50, twiddle_eap_5_1);
 		asSystemJar.put(IServerConstants.SERVER_EAP_60, eap_server_6_0_jar);
@@ -262,6 +264,10 @@ public class MockServerCreationUtilities extends Assert {
 			serverDir = createWildfly240MockServerDirectory(name, serverType, asSystemJar.get(serverType));
 		} else if (IServerConstants.SERVER_WILDFLY_270.equals(serverType)) {
 			serverDir = createWildfly270MockServerDirectory(name, serverType, asSystemJar.get(serverType));
+		} else if (IServerConstants.SERVER_WILDFLY_350.equals(serverType)) {
+			serverDir = createWildfly350MockServerDirectory(name, serverType, asSystemJar.get(serverType));
+		} else if (IServerConstants.SERVER_WILDFLY_380.equals(serverType)) {
+			serverDir = createWildfly380MockServerDirectory(name, serverType, asSystemJar.get(serverType));
 		} else if (TEST_SERVER_TYPE_GATEIN_34.equals(serverType)) {
 			serverDir = createGateIn34MockServerDirectory(name);
 		} else if (TEST_SERVER_TYPE_GATEIN_35.equals(serverType)) {
@@ -428,8 +434,16 @@ public class MockServerCreationUtilities extends Assert {
 				"JBoss-Product-Release-Name: WildFly Full\nJBoss-Product-Release-Version: 24.0.0.Final\n");
 	}
 	private static File createWildfly270MockServerDirectory(String name, String serverTypeId, String serverJar) {
-		return createWildflyServerDirectory(name, serverTypeId, serverJar, "main", 
+		return createWildflyServerDirectory(name, serverTypeId, serverJar, "main",
 				"JBoss-Product-Release-Name: WildFly Full\nJBoss-Product-Release-Version: 27.0.0.Final\n");
+	}
+	private static File createWildfly350MockServerDirectory(String name, String serverTypeId, String serverJar) {
+		return createWildflyServerDirectory(name, serverTypeId, serverJar, "main",
+				"JBoss-Product-Release-Name: WildFly Full\nJBoss-Product-Release-Version: 35.0.0.Final\n");
+	}
+	private static File createWildfly380MockServerDirectory(String name, String serverTypeId, String serverJar) {
+		return createWildflyServerDirectory(name, serverTypeId, serverJar, "main",
+				"JBoss-Product-Release-Name: WildFly Full\nJBoss-Product-Release-Version: 38.0.0.Final\n");
 	}
 
 	private static File createWildflyServerDirectory(String name, String serverTypeId, String serverJar, String manString) {

--- a/runtimes/tests/org.jboss.tools.rsp.server.wildfly.test/src/main/java/org/jboss/tools/rsp/server/wildfly/test/beans/ServerBeanTypeTest.java
+++ b/runtimes/tests/org.jboss.tools.rsp.server.wildfly.test/src/main/java/org/jboss/tools/rsp/server/wildfly/test/beans/ServerBeanTypeTest.java
@@ -91,6 +91,8 @@ public class ServerBeanTypeTest {
 		map.put(IServerConstants.SERVER_WILDFLY_230, new ServerBeanTypeMock(ID_WILDFLY, NAME_WILDFLY, IServerConstants.SERVER_WILDFLY_230, "23.0"));
 		map.put(IServerConstants.SERVER_WILDFLY_240, new ServerBeanTypeMock(ID_WILDFLY, NAME_WILDFLY, IServerConstants.SERVER_WILDFLY_240, "24.0"));
 		map.put(IServerConstants.SERVER_WILDFLY_270, new ServerBeanTypeMock(ID_WILDFLY, NAME_WILDFLY, IServerConstants.SERVER_WILDFLY_270, "27.0"));
+		map.put(IServerConstants.SERVER_WILDFLY_350, new ServerBeanTypeMock(ID_WILDFLY, NAME_WILDFLY, IServerConstants.SERVER_WILDFLY_350, "35.0"));
+		map.put(IServerConstants.SERVER_WILDFLY_380, new ServerBeanTypeMock(ID_WILDFLY, NAME_WILDFLY, IServerConstants.SERVER_WILDFLY_380, "38.0"));
 		// NEW_SERVER_ADAPTER
 		return map;
 	}


### PR DESCRIPTION
- WildFly 35+ (versions 35-37): Java 17-21 support
- WildFly 38+ (versions 38+): Java 17-25 support

Added server constants, extended properties, bean types, and factory entries for both new server types following established patterns.