### PR TITLE
Fixes #738 - Add JDK serial filter to WildFly launch arguments

### DIFF
--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/capabilities/WildFlyExtendedProperties.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/capabilities/WildFlyExtendedProperties.java
@@ -13,6 +13,7 @@ package org.jboss.tools.rsp.server.wildfly.servertype.capabilities;
 import org.jboss.tools.rsp.server.spi.servertype.IServer;
 import org.jboss.tools.rsp.server.wildfly.servertype.launch.Wildfly100DefaultLaunchArguments;
 import org.jboss.tools.rsp.server.wildfly.servertype.launch.Wildfly110DefaultLaunchArguments;
+import org.jboss.tools.rsp.server.wildfly.servertype.launch.Wildfly340DefaultLaunchArguments;
 import org.jboss.tools.rsp.server.wildfly.servertype.launch.Wildfly80DefaultLaunchArguments;
 
 public class WildFlyExtendedProperties {
@@ -114,12 +115,12 @@ public class WildFlyExtendedProperties {
 	}
 	public static class Wildfly350ExtendedProperties extends AbstractWildflyExtendedProperties {
 		public Wildfly350ExtendedProperties(IServer server) {
-			super("35.0", "17", "21.", HTTP_REMOTING_JMX_NEW, new Wildfly110DefaultLaunchArguments(server), server);
+			super("35.0", "17", "21.", HTTP_REMOTING_JMX_NEW, new Wildfly340DefaultLaunchArguments(server), server);
 		}
 	}
 	public static class Wildfly380ExtendedProperties extends AbstractWildflyExtendedProperties {
 		public Wildfly380ExtendedProperties(IServer server) {
-			super("38.0", "17", "25.", HTTP_REMOTING_JMX_NEW, new Wildfly110DefaultLaunchArguments(server), server);
+			super("38.0", "17", "25.", HTTP_REMOTING_JMX_NEW, new Wildfly340DefaultLaunchArguments(server), server);
 		}
 	}
 	// NEW_SERVER_ADAPTER

--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/launch/Wildfly340DefaultLaunchArguments.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/launch/Wildfly340DefaultLaunchArguments.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.rsp.server.wildfly.servertype.launch;
+
+import org.jboss.tools.rsp.server.spi.servertype.IServer;
+
+public class Wildfly340DefaultLaunchArguments extends JBoss71DefaultLaunchArguments {
+	public Wildfly340DefaultLaunchArguments(IServer s) {
+		super(s);
+	}
+
+	@Override
+	protected String getMemoryArgs() {
+		return "-Xms64m -Xmx512m "; //$NON-NLS-1$
+	}
+
+	@Override
+	public String getStartDefaultVMArgs() {
+		return super.getStartDefaultVMArgs()
+				+ "-Dorg.jboss.logmanager.nocolor=true -Djboss.bind.address.management=localhost " //$NON-NLS-1$
+				+ getJdkSerialFilter();
+	}
+
+	@Override
+	protected String getJaxpProvider() {
+		return ""; //$NON-NLS-1$
+	}
+
+	/**
+	 * Returns the JDK serial filter argument for protection against deserialization attacks.
+	 *
+	 * @return the serial filter argument
+	 */
+	protected String getJdkSerialFilter() {
+		return "-Djdk.serialFilter=\"maxbytes=10485760;maxdepth=128;maxarray=100000;maxrefs=300000\" "; //$NON-NLS-1$
+	}
+
+}


### PR DESCRIPTION
## Summary

This PR adds the JDK serialization filter to WildFly 34+ launch arguments for protection against deserialization attacks, matching the behavior of WildFly's startup scripts.

## Changes

- Created `Wildfly340DefaultLaunchArguments` class with JDK serial filter argument
- Updated `Wildfly350ExtendedProperties` to use the new launch arguments class
- Updated `Wildfly380ExtendedProperties` to use the new launch arguments class

## Technical Details

The serial filter is applied with the following limits (matching WildFly startup scripts):
- `maxbytes=10485760` - Max serialized data size: 10MB
- `maxdepth=128` - Max object graph depth
- `maxarray=100000` - Max array size
- `maxrefs=300000` - Max object references

## Testing

This should be tested with WildFly 35+ and 38+ to ensure:
- The JVM argument is properly applied
- Server starts successfully with the filter in place
- No compatibility issues

Fixes #738