### PR TITLE
Add wildfly.management.port attribute for custom management port

### DIFF
--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/IJBossServerAttributes.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/IJBossServerAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * Copyright (c) 2018, 2026 Red Hat, Inc. Distributed under license by Red Hat, Inc.
  * All rights reserved. This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v20.html
@@ -27,6 +27,8 @@ public interface IJBossServerAttributes extends DefaultServerAttributes {
 	public static final String JBOSS_SERVER_HOST_DEFAULT = "localhost";
 	public static final String JBOSS_SERVER_PORT = "jboss.server.port";
 	public static final int JBOSS_SERVER_PORT_DEFAULT = 8080;
+	public static final String WILDFLY_MANAGEMENT_PORT = "wildfly.management.port";
+	public static final int WILDFLY_MANAGEMENT_PORT_DEFAULT = 9990;
 
 	public static final String WILDFLY_CONFIG_FILE_DEFAULT = "standalone.xml";
 	public static final String WILDFLY_CONFIG_FILE = "wildfly.server.config.file";

--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/impl/WildFlyServerType.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/impl/WildFlyServerType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * Copyright (c) 2018, 2026 Red Hat, Inc. Distributed under license by Red Hat, Inc.
  * All rights reserved. This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v20.html
@@ -37,9 +37,14 @@ public class WildFlyServerType extends BaseJBossServerType {
 				"Set the configuration file you want your WildFly instance to use. Path must be relative to base directory's configuration folder.", 
 				IJBossServerAttributes.WILDFLY_CONFIG_FILE_DEFAULT);
 
-		attrs.addAttribute(IJBossServerAttributes.WILDFLY_DEPLOY_DIR, 
-				ServerManagementAPIConstants.ATTR_TYPE_LOCAL_FOLDER, 
-				"Override the directory tools should deploy to. Path may be relative to the server home, or absolute.", 
+		attrs.addAttribute(IJBossServerAttributes.WILDFLY_DEPLOY_DIR,
+				ServerManagementAPIConstants.ATTR_TYPE_LOCAL_FOLDER,
+				"Override the directory tools should deploy to. Path may be relative to the server home, or absolute.",
 				"");
+
+		attrs.addAttribute(IJBossServerAttributes.WILDFLY_MANAGEMENT_PORT,
+				ServerManagementAPIConstants.ATTR_TYPE_INT,
+				"Set the management port for WildFly (default 9990). Used when stopping the server via the management CLI.",
+				IJBossServerAttributes.WILDFLY_MANAGEMENT_PORT_DEFAULT);
 	}
 }

--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/launch/AbstractWildFlyDefaultLaunchArguments.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/launch/AbstractWildFlyDefaultLaunchArguments.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * All rights reserved. This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is
+ * available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors: Red Hat, Inc.
+ ******************************************************************************/
+package org.jboss.tools.rsp.server.wildfly.servertype.launch;
+
+import org.jboss.tools.rsp.eclipse.core.runtime.IPath;
+import org.jboss.tools.rsp.server.spi.servertype.IServer;
+import org.jboss.tools.rsp.server.wildfly.servertype.IJBossServerAttributes;
+
+public abstract class AbstractWildFlyDefaultLaunchArguments extends JBoss71DefaultLaunchArguments {
+	public AbstractWildFlyDefaultLaunchArguments(IServer s) {
+		super(s);
+	}
+
+	@Override
+	public String getDefaultStopArgs() {
+		IPath modules = getServerHome().append("modules");
+		String controllerArg = getControllerArg();
+		return "-mp \"" + modules.toOSString() + "\" org.jboss.as.cli --connect"
+				+ controllerArg + " command=:shutdown";
+	}
+
+	private String getControllerArg() {
+		if (server == null) {
+			return "";
+		}
+		int port = server.getAttribute(IJBossServerAttributes.WILDFLY_MANAGEMENT_PORT,
+				IJBossServerAttributes.WILDFLY_MANAGEMENT_PORT_DEFAULT);
+		if (port == IJBossServerAttributes.WILDFLY_MANAGEMENT_PORT_DEFAULT) {
+			return "";
+		}
+		String host = server.getAttribute(IJBossServerAttributes.JBOSS_SERVER_HOST,
+				IJBossServerAttributes.JBOSS_SERVER_HOST_DEFAULT);
+		if (host == null || host.isEmpty()) {
+			host = IJBossServerAttributes.JBOSS_SERVER_HOST_DEFAULT;
+		}
+		return " --controller=" + host + ":" + port;
+	}
+}

--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/launch/Wildfly100DefaultLaunchArguments.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/launch/Wildfly100DefaultLaunchArguments.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Copyright (c) 2007 - 2013, 2026 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -12,7 +12,7 @@ package org.jboss.tools.rsp.server.wildfly.servertype.launch;
 
 import org.jboss.tools.rsp.server.spi.servertype.IServer;
 
-public class Wildfly100DefaultLaunchArguments extends JBoss71DefaultLaunchArguments {
+public class Wildfly100DefaultLaunchArguments extends AbstractWildFlyDefaultLaunchArguments {
 	public Wildfly100DefaultLaunchArguments(IServer s) {
 		super(s);
 	}

--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/launch/Wildfly340DefaultLaunchArguments.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/launch/Wildfly340DefaultLaunchArguments.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Copyright (c) 2007 - 2013, 2026 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -12,7 +12,7 @@ package org.jboss.tools.rsp.server.wildfly.servertype.launch;
 
 import org.jboss.tools.rsp.server.spi.servertype.IServer;
 
-public class Wildfly340DefaultLaunchArguments extends JBoss71DefaultLaunchArguments {
+public class Wildfly340DefaultLaunchArguments extends AbstractWildFlyDefaultLaunchArguments {
 	public Wildfly340DefaultLaunchArguments(IServer s) {
 		super(s);
 	}

--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/launch/Wildfly80DefaultLaunchArguments.java
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/src/main/java/org/jboss/tools/rsp/server/wildfly/servertype/launch/Wildfly80DefaultLaunchArguments.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007 - 2013 Red Hat, Inc.
+ * Copyright (c) 2007 - 2013, 2026 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -13,7 +13,7 @@ package org.jboss.tools.rsp.server.wildfly.servertype.launch;
 import org.jboss.tools.rsp.eclipse.core.runtime.IPath;
 import org.jboss.tools.rsp.server.spi.servertype.IServer;
 
-public class Wildfly80DefaultLaunchArguments extends JBoss71DefaultLaunchArguments {
+public class Wildfly80DefaultLaunchArguments extends AbstractWildFlyDefaultLaunchArguments {
 
 	public Wildfly80DefaultLaunchArguments(IServer s) {
 		super(s);

--- a/runtimes/tests/org.jboss.tools.rsp.server.wildfly.test/src/main/java/org/jboss/tools/rsp/server/wildfly/test/servertype/WildFlyServerAttributesTest.java
+++ b/runtimes/tests/org.jboss.tools.rsp.server.wildfly.test/src/main/java/org/jboss/tools/rsp/server/wildfly/test/servertype/WildFlyServerAttributesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Red Hat, Inc. Distributed under license by Red Hat, Inc.
+ * Copyright (c) 2020, 2026 Red Hat, Inc. Distributed under license by Red Hat, Inc.
  * All rights reserved. This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution, and is
  * available at http://www.eclipse.org/legal/epl-v20.html
@@ -8,6 +8,7 @@
  ******************************************************************************/
 package org.jboss.tools.rsp.server.wildfly.test.servertype;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
@@ -36,6 +37,7 @@ import org.jboss.tools.rsp.server.spi.servertype.IServerWorkingCopy;
 import org.jboss.tools.rsp.server.wildfly.servertype.IJBossServerAttributes;
 import org.jboss.tools.rsp.server.wildfly.servertype.impl.ServerTypeStringConstants;
 import org.jboss.tools.rsp.server.wildfly.servertype.impl.WildFlyServerDelegate;
+import org.jboss.tools.rsp.server.wildfly.servertype.launch.Wildfly340DefaultLaunchArguments;
 import org.junit.Test;
 
 public class WildFlyServerAttributesTest {
@@ -79,6 +81,46 @@ public class WildFlyServerAttributesTest {
 		String[] cmdLine = det.getCmdLine();
 		
 		assertTrue(isFound(cmdLine, "-Djboss.http.port=8500"));
+	}
+
+	@Test
+	public void testDefaultManagementPortOmitsController() throws IOException {
+		IServer server = mockServer();
+
+		File f = Files.createTempDirectory(System.currentTimeMillis() + "_wfly").toFile();
+		f.mkdirs();
+		new File(f, "modules").mkdirs();
+
+		doReturn(f.getAbsolutePath()).when(server).getAttribute(eq(IJBossServerAttributes.SERVER_HOME), anyString());
+		doReturn(f.getAbsolutePath()).when(server).getAttribute(IJBossServerAttributes.SERVER_HOME, (String)null);
+
+		doReturn(9990).when(server).getAttribute(eq(IJBossServerAttributes.WILDFLY_MANAGEMENT_PORT), anyInt());
+
+		Wildfly340DefaultLaunchArguments args = new Wildfly340DefaultLaunchArguments(server);
+		String stopArgs = args.getDefaultStopArgs();
+
+		assertTrue(stopArgs.contains("command=:shutdown"));
+		assertFalse(stopArgs.contains("--controller"));
+	}
+
+	@Test
+	public void testCustomManagementPortIncludesController() throws IOException {
+		IServer server = mockServer();
+
+		File f = Files.createTempDirectory(System.currentTimeMillis() + "_wfly").toFile();
+		f.mkdirs();
+		new File(f, "modules").mkdirs();
+
+		doReturn(f.getAbsolutePath()).when(server).getAttribute(eq(IJBossServerAttributes.SERVER_HOME), anyString());
+		doReturn(f.getAbsolutePath()).when(server).getAttribute(IJBossServerAttributes.SERVER_HOME, (String)null);
+
+		doReturn(49990).when(server).getAttribute(eq(IJBossServerAttributes.WILDFLY_MANAGEMENT_PORT), anyInt());
+
+		Wildfly340DefaultLaunchArguments args = new Wildfly340DefaultLaunchArguments(server);
+		String stopArgs = args.getDefaultStopArgs();
+
+		assertTrue(stopArgs.contains("--controller=localhost:49990"));
+		assertTrue(stopArgs.contains("command=:shutdown"));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- Add optional `wildfly.management.port` attribute to WildFly server types, allowing users to configure a non-default management port (e.g. 49990 instead of 9990)
- When set, the shutdown CLI command includes `--controller=host:port` so the RSP can stop WildFly instances with custom management ports
- Introduce `AbstractWildFlyDefaultLaunchArguments` as an intermediate class between `JBoss71DefaultLaunchArguments` and WildFly subclasses to scope this behavior to WildFly only

Fixes #743

## Test plan

- [ ] Unit tests verify default port omits `--controller` flag
- [ ] Unit tests verify custom port produces `--controller=localhost:<port>`
- [ ] Host defaults to `localhost` when not explicitly configured (null-safe)
- [ ] All 135 existing wildfly tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)