### PR TITLE
Terminate lingering server processes after shutdown

### DIFF
--- a/framework/bundles/org.jboss.tools.rsp.server.generic/src/main/java/org/jboss/tools/rsp/server/generic/servertype/GenericServerBehavior.java
+++ b/framework/bundles/org.jboss.tools.rsp.server.generic/src/main/java/org/jboss/tools/rsp/server/generic/servertype/GenericServerBehavior.java
@@ -411,6 +411,54 @@ public class GenericServerBehavior extends AbstractServerDelegate
 		}
 	}
 
+	private static final long PROCESS_CLEANUP_DELAY_MS = 120_000;
+
+	@Override
+	protected IPollResultListener shutdownServerResultListener() {
+		IPollResultListener delegate = super.shutdownServerResultListener();
+		return new IPollResultListener() {
+			@Override
+			public void stateNotAsserted(IServerStatePoller.SERVER_STATE expectedState,
+					IServerStatePoller.SERVER_STATE currentState) {
+				delegate.stateNotAsserted(expectedState, currentState);
+			}
+
+			@Override
+			public void stateAsserted(IServerStatePoller.SERVER_STATE expectedState,
+					IServerStatePoller.SERVER_STATE currentState) {
+				ILaunch launch = getStartLaunch();
+				delegate.stateAsserted(expectedState, currentState);
+				if (currentState == IServerStatePoller.SERVER_STATE.DOWN && launch != null) {
+					scheduleProcessTermination(launch);
+				}
+			}
+		};
+	}
+
+	private void scheduleProcessTermination(ILaunch launch) {
+		Thread t = new Thread(() -> {
+			try {
+				Thread.sleep(PROCESS_CLEANUP_DELAY_MS);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return;
+			}
+			for (IProcess p : launch.getProcesses()) {
+				if (!p.isTerminated()) {
+					try {
+						LOG.info("Terminating lingering server process for {}",
+								getServer().getName());
+						p.terminate();
+					} catch (DebugException e) {
+						LOG.error("Failed to terminate lingering server process", e);
+					}
+				}
+			}
+		}, "Process cleanup: " + getServer().getName());
+		t.setDaemon(true);
+		t.start();
+	}
+
 	@Override
 	public IStatus clientSetServerStarted(LaunchParameters attr) {
 		setServerState(STATE_STARTED, true);


### PR DESCRIPTION
## Summary
- When a server's HTTP port stops responding but the JVM process doesn't exit (e.g., non-daemon threads or hung shutdown hooks in the deployed application), the framework declares the server stopped without killing the process
- On the next start, the old launch reference is overwritten, orphaning the JVM — repeated restarts accumulate zombie processes until memory is exhausted
- Overrides `shutdownServerResultListener()` in `GenericServerBehavior` to schedule a non-blocking background cleanup after the poller confirms the port is down — a daemon thread waits 2 minutes for the process to exit naturally, then force-terminates any survivors

🤖 Generated with [Claude Code](https://claude.com/claude-code)