### PR TITLE
Update minimum Java baseline from 8 to 11

### DIFF
--- a/api/bundles/org.jboss.tools.rsp.api/META-INF/MANIFEST.MF
+++ b/api/bundles/org.jboss.tools.rsp.api/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.jboss.tools.rsp.api
 Bundle-SymbolicName: org.jboss.tools.rsp.api
 Bundle-Version: 0.26.22.qualifier
 Automatic-Module-Name: org.jboss.tools.rsp.api
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .
 Import-Package: org.osgi.framework,
  org.eclipse.lsp4j.jsonrpc,

--- a/framework/bundles/org.jboss.tools.rsp.foundation.core/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.jboss.tools.rsp.foundation.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.jboss.tools.rsp.foundation.core
 Bundle-SymbolicName: org.jboss.tools.rsp.foundation.core
 Bundle-Version: 0.26.22.qualifier
 Bundle-Activator: org.jboss.tools.rsp.foundation.core.FoundationCoreActivator
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.jboss.tools.rsp.api.dao,
  org.jboss.tools.rsp.eclipse.core.runtime,
  org.jboss.tools.rsp.eclipse.debug.core,

--- a/framework/bundles/org.jboss.tools.rsp.launching.java/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.jboss.tools.rsp.launching.java/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.jboss.tools.rsp.launching.java
 Bundle-SymbolicName: org.jboss.tools.rsp.launching.java
 Automatic-Module-Name: org.jboss.tools.rsp.launching.java
 Bundle-Version: 0.26.22.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Activator: org.jboss.tools.rsp.launching.java.JavaLaunchingActivator
 Bundle-ClassPath: .
 Import-Package: com.google.gson,

--- a/framework/bundles/org.jboss.tools.rsp.launching/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.jboss.tools.rsp.launching/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.jboss.tools.rsp.launching
 Bundle-SymbolicName: org.jboss.tools.rsp.launching
 Automatic-Module-Name: org.jboss.tools.rsp.launching
 Bundle-Version: 0.26.22.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Activator: org.jboss.tools.rsp.launching.internal.LaunchingActivator
 Bundle-ClassPath: .
 Import-Package: com.google.gson,

--- a/framework/bundles/org.jboss.tools.rsp.logging/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.jboss.tools.rsp.logging/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.jboss.tools.rsp.logging
 Bundle-SymbolicName: org.jboss.tools.rsp.logging
 Bundle-Version: 0.26.22.qualifier
 Bundle-Activator: org.jboss.tools.rsp.logging.LoggingActivator
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: ch.qos.logback.classic,
  ch.qos.logback.core.spi,
  org.jboss.tools.rsp.eclipse.osgi.util,

--- a/framework/bundles/org.jboss.tools.rsp.runtime.core/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.jboss.tools.rsp.runtime.core/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.jboss.tools.rsp.runtime.core
 Bundle-Version: 0.26.22.qualifier
 Bundle-Activator: org.jboss.tools.rsp.runtime.core.RuntimeCoreActivator
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %BundleVendor
 Bundle-Localization: plugin
 Export-Package: org.jboss.tools.rsp.runtime.core,

--- a/framework/bundles/org.jboss.tools.rsp.secure/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.jboss.tools.rsp.secure/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.jboss.tools.rsp.secure
 Bundle-SymbolicName: org.jboss.tools.rsp.secure
 Automatic-Module-Name: org.jboss.tools.rsp.secure
 Bundle-Version: 0.26.22.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Activator: org.jboss.tools.rsp.secure.SecureActivator
 Bundle-ClassPath: .
 Import-Package: com.google.gson,

--- a/framework/bundles/org.jboss.tools.rsp.server.generic/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.jboss.tools.rsp.server.generic/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.jboss.tools.rsp.server.generic
 Bundle-SymbolicName: org.jboss.tools.rsp.server.generic
 Automatic-Module-Name: org.jboss.tools.rsp.server.generic
 Bundle-Version: 0.26.22.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.eclipse.lsp4j.jsonrpc,
  org.eclipse.lsp4j.jsonrpc.json,
  org.eclipse.lsp4j.jsonrpc.json.adapters,

--- a/framework/bundles/org.jboss.tools.rsp.server.spi/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.jboss.tools.rsp.server.spi/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.jboss.tools.rsp.server.spi
 Automatic-Module-Name: org.jboss.tools.rsp.server.spi
 Bundle-Activator: org.jboss.tools.rsp.server.spi.SPIActivator
 Bundle-Version: 0.26.22.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.jboss.tools.rsp.api,
  org.jboss.tools.rsp.api.dao,
  org.jboss.tools.rsp.api.dao.util,

--- a/framework/bundles/org.jboss.tools.rsp.server/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.jboss.tools.rsp.server/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.jboss.tools.rsp.server
 Bundle-SymbolicName: org.jboss.tools.rsp.server
 Automatic-Module-Name: org.jboss.tools.rsp.server
 Bundle-Version: 0.26.22.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Activator: org.jboss.tools.rsp.server.ServerCoreActivator
 Import-Package: com.google.gson,
  org.eclipse.lsp4j.jsonrpc,

--- a/framework/bundles/org.jboss.tools.rsp.stacks.core/META-INF/MANIFEST.MF
+++ b/framework/bundles/org.jboss.tools.rsp.stacks.core/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: %BundleVendor
 Bundle-SymbolicName: org.jboss.tools.rsp.stacks.core
 Bundle-Version: 0.26.22.qualifier
 Bundle-Activator: org.jboss.tools.rsp.stacks.core.StacksCoreActivator
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,
  lib/httpclient-4.0.1.jar,

--- a/framework/tests/org.jboss.tools.rsp.launching.java.test/META-INF/MANIFEST.MF
+++ b/framework/tests/org.jboss.tools.rsp.launching.java.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.jboss.tools.rsp.launching.java.test
 Automatic-Module-Name: org.jboss.tools.rsp.launching.java.test
 Bundle-Version: 0.26.22.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .
 Import-Package: com.google.gson,
  javax.xml.parsers,

--- a/framework/tests/org.jboss.tools.rsp.launching.test/META-INF/MANIFEST.MF
+++ b/framework/tests/org.jboss.tools.rsp.launching.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.jboss.tools.rsp.launching.test
 Automatic-Module-Name: org.jboss.tools.rsp.launching.java.test
 Bundle-Version: 0.26.22.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .
 Require-Bundle: org.jboss.tools.rsp.launching;bundle-version="0.0.9",
  org.junit,

--- a/framework/tests/org.jboss.tools.rsp.runtime.core.test/META-INF/MANIFEST.MF
+++ b/framework/tests/org.jboss.tools.rsp.runtime.core.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Runtime Core Test
 Bundle-SymbolicName: org.jboss.tools.rsp.runtime.core.test
 Bundle-Version: 0.26.22.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.jboss.tools.rsp.runtime.core.test
 Import-Package: org.osgi.framework
 Require-Bundle: org.jboss.tools.rsp.runtime.core;bundle-version="0.11.0",

--- a/framework/tests/org.jboss.tools.rsp.secure.test/META-INF/MANIFEST.MF
+++ b/framework/tests/org.jboss.tools.rsp.secure.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Secure Storage Test
 Bundle-SymbolicName: org.jboss.tools.rsp.secure.test
 Bundle-Version: 0.26.22.qualifier
 Bundle-Activator: org.jboss.tools.rsp.secure.test.Activator
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.jboss.tools.rsp.secure.test
 Import-Package: org.osgi.framework
 Require-Bundle: org.junit;bundle-version="4.8.1",

--- a/framework/tests/org.jboss.tools.rsp.server.generic.test/META-INF/MANIFEST.MF
+++ b/framework/tests/org.jboss.tools.rsp.server.generic.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.jboss.tools.rsp.server.generic.test.generic.test
 Bundle-SymbolicName: org.jboss.tools.rsp.server.generic.test.generic.test
 Automatic-Module-Name: org.jboss.tools.rsp.server.generic.test.generic.test
 Bundle-Version: 0.26.22.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.eclipse.lsp4j.jsonrpc,
  org.jboss.tools.rsp.api,
  org.jboss.tools.rsp.api.dao,

--- a/framework/tests/org.jboss.tools.rsp.server.spi.test/META-INF/MANIFEST.MF
+++ b/framework/tests/org.jboss.tools.rsp.server.spi.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.jboss.tools.rsp.server.spi.test
 Bundle-SymbolicName: org.jboss.tools.rsp.server.spi.test
 Automatic-Module-Name: org.jboss.tools.rsp.server.spi.test
 Bundle-Version: 0.26.22.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.osgi.framework,
  org.osgi.service.log
 Require-Bundle: org.jboss.tools.rsp.api;bundle-version="0.10.0",

--- a/framework/tests/org.jboss.tools.rsp.server.test/META-INF/MANIFEST.MF
+++ b/framework/tests/org.jboss.tools.rsp.server.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.jboss.tools.rsp.server.test
 Bundle-SymbolicName: org.jboss.tools.rsp.server.test
 Automatic-Module-Name: org.jboss.tools.rsp.server.test
 Bundle-Version: 0.26.22.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: com.google.gson;version="2.8.7",
  org.eclipse.lsp4j.jsonrpc,
  org.jboss.tools.rsp.api,

--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,8 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
-						<source>1.8</source>
-						<target>1.8</target>
+						<source>11</source>
+						<target>11</target>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/runtimes/bundles/org.jboss.tools.rsp.server.minishift/META-INF/MANIFEST.MF
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.minishift/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.jboss.tools.rsp.server.minishift
 Bundle-Activator: org.jboss.tools.rsp.server.minishift.impl.Activator
 Automatic-Module-Name: org.jboss.tools.rsp.server.minishift
 Bundle-Version: 0.26.22.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.eclipse.lsp4j.jsonrpc,
  org.eclipse.lsp4j.jsonrpc.json,
  org.eclipse.lsp4j.jsonrpc.json.adapters,

--- a/runtimes/bundles/org.jboss.tools.rsp.server.redhat.download/META-INF/MANIFEST.MF
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.redhat.download/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.jboss.tools.rsp.server.redhat.download
 Bundle-Activator: org.jboss.tools.rsp.server.redhat.download.impl.Activator
 Automatic-Module-Name: org.jboss.tools.rsp.server.redhat.download
 Bundle-Version: 0.26.22.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.eclipse.lsp4j.jsonrpc,
  org.eclipse.lsp4j.jsonrpc.json,
  org.eclipse.lsp4j.jsonrpc.json.adapters,

--- a/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/META-INF/MANIFEST.MF
+++ b/runtimes/bundles/org.jboss.tools.rsp.server.wildfly/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.jboss.tools.rsp.server.wildfly
 Bundle-Activator: org.jboss.tools.rsp.server.wildfly.impl.Activator
 Automatic-Module-Name: org.jboss.tools.rsp.server.wildfly
 Bundle-Version: 0.26.22.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.eclipse.lsp4j.jsonrpc,
  org.eclipse.lsp4j.jsonrpc.json,
  org.eclipse.lsp4j.jsonrpc.json.adapters,

--- a/runtimes/tests/org.jboss.tools.rsp.server.wildfly.test/META-INF/MANIFEST.MF
+++ b/runtimes/tests/org.jboss.tools.rsp.server.wildfly.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.jboss.tools.rsp.server.wildfly.test
 Bundle-SymbolicName: org.jboss.tools.rsp.server.wildfly.test
 Automatic-Module-Name: org.jboss.tools.rsp.server.wildfly.test
 Bundle-Version: 0.26.22.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.assertj.core.api,
  org.eclipse.lsp4j.jsonrpc,
  org.eclipse.lsp4j.jsonrpc.json,

--- a/targetplatform/rsp-target.target
+++ b/targetplatform/rsp-target.target
@@ -84,7 +84,7 @@
 
 	</locations>
 	<targetJRE
-		path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8" />
+		path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11" />
 
 
 </target>


### PR DESCRIPTION
## Summary
- The codebase already uses Java 9+ APIs (e.g., `ProcessHandle` in `RuntimeProcess`) but all MANIFEST.MF files declared `JavaSE-1.8` and the Maven compiler targeted 1.8
- CI has been building on Java 11+ for some time — the declared baseline was stale and misleading
- Updates `Bundle-RequiredExecutionEnvironment` to `JavaSE-11` in all 22 bundle and test MANIFEST.MF files
- Updates `maven-compiler-plugin` source/target from 1.8 to 11
- Updates target platform JRE from `JavaSE-1.8` to `JavaSE-11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)